### PR TITLE
Fixed to work on windows machines

### DIFF
--- a/src/SimpleDTO.php
+++ b/src/SimpleDTO.php
@@ -200,7 +200,7 @@ abstract class SimpleDTO implements JsonSerializable, Serializable
                 throw new InvalidDataTypeException('A class data type docblock is malformed.');
             }
 
-            $this->dataTypeRules[substr($prop[1], 1)] = $prop[0];
+            $this->dataTypeRules[trim(substr($prop[1], 1))] = $prop[0];
         }
     }
 


### PR DESCRIPTION
DTO properties need to be trimmed due to DTO's created on Windows boxes receiving error "Undefined Property" during validation.